### PR TITLE
avoid second use of get()

### DIFF
--- a/src/java/org/apache/cassandra/streaming/StreamSession.java
+++ b/src/java/org/apache/cassandra/streaming/StreamSession.java
@@ -370,8 +370,10 @@ public class StreamSession implements IEndpointStateChangeSubscriber
             if (task == null)
             {
                 //guarantee atomicity
-                transfers.putIfAbsent(cfId, new StreamTransferTask(this, cfId));
-                task = transfers.get(cfId);
+                StreamTransferTask newTask = new StreamTransferTask(this, cfId);
+                task = transfers.putIfAbsent(cfId, newTask);
+                if (task == null)
+                    task = newTask;
             }
             task.addTransferFile(details.ref, details.estimatedKeys, details.sections, details.repairedAt);
             iter.remove();

--- a/src/java/org/apache/cassandra/thrift/ThriftSessionManager.java
+++ b/src/java/org/apache/cassandra/thrift/ThriftSessionManager.java
@@ -58,8 +58,10 @@ public class ThriftSessionManager
         if (cState == null)
         {
             //guarantee atomicity
-            activeSocketSessions.putIfAbsent(socket, new ThriftClientState(socket));
-            cState = activeSocketSessions.get(socket);
+            ThriftClientState newState = new ThriftClientState(socket);
+            cState = activeSocketSessions.putIfAbsent(socket, newState);
+            if (cState == null)
+                cState = newState;
         }
         return cState;
     }


### PR DESCRIPTION
Tiny update not to do `get()`.

testall passes: http://cassci.datastax.com/view/Dev/view/yukim/job/yukim-7757-2.1-2-testall/1/
